### PR TITLE
Remove duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "loophole": "^1.1.0",
     "xo": "^0.11.0"
   },
-  "devDependencies": {
-    "xo": "*"
-  },
   "package-deps": [
     "linter"
   ],


### PR DESCRIPTION
```sh
~/.a/p/linter-xo ❯❯❯ npm install
npm WARN package.json Dependency 'xo' exists in both dependencies and devDependencies, using 'xo@^0.11.0' from dependencies
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sindresorhus/atom-linter-xo/8)
<!-- Reviewable:end -->
