### PR TITLE
Set the lint working dir to the package dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import path from 'path';
 import {CompositeDisposable} from 'atom';
 import {allowUnsafeNewFunction} from 'loophole';
 import setText from 'atom-set-text';
+import pkgDir from 'pkg-dir';
 
 let lintText;
 allowUnsafeNewFunction(() => {
@@ -13,12 +14,14 @@ function lint(textEditor) {
 	const filePath = textEditor.getPath();
 	let report;
 
+	const dir = pkgDir.sync(path.dirname(filePath));
+
 	// ugly hack to workaround ESLint's lack of a `cwd` option
 	const defaultCwd = process.cwd();
-	process.chdir(path.dirname(filePath));
+	process.chdir(dir);
 
 	allowUnsafeNewFunction(() => {
-		report = lintText(textEditor.getText(), {cwd: path.dirname(filePath)});
+		report = lintText(textEditor.getText(), {cwd: dir});
 	});
 
 	process.chdir(defaultCwd);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "atom-package-deps": "^3.0.0",
     "atom-set-text": "^1.0.1",
     "loophole": "^1.1.0",
+    "pkg-dir": "^1.0.0",
     "xo": "^0.11.1"
   },
   "package-deps": [


### PR DESCRIPTION
ESLint needs the cwd to be the package root in order to find the installed eslint plugins

Fixes #10