### PR TITLE
Disable for non-XO projects 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /** @babel */
+import fs from 'fs';
 import path from 'path';
 import {CompositeDisposable} from 'atom';
 import {allowUnsafeNewFunction} from 'loophole';
@@ -18,6 +19,13 @@ function lint(textEditor) {
 
 	// no package.json
 	if (!dir) {
+		return [];
+	}
+
+	// check if package.json has 'xo'
+	const rgx = new RegExp('xo', 'g');
+	const pkg = fs.readFileSync(path.join(dir, 'package.json'), 'utf8');
+	if (!rgx.test(pkg)) {
 		return [];
 	}
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,11 @@ function lint(textEditor) {
 
 	const dir = pkgDir.sync(path.dirname(filePath));
 
+	// no package.json
+	if (!dir) {
+		return [];
+	}
+
 	// ugly hack to workaround ESLint's lack of a `cwd` option
 	const defaultCwd = process.cwd();
 	process.chdir(dir);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 /** @babel */
-import fs from 'fs';
 import path from 'path';
 import {CompositeDisposable} from 'atom';
 import {allowUnsafeNewFunction} from 'loophole';
 import setText from 'atom-set-text';
 import pkgDir from 'pkg-dir';
+import {sync as loadJson} from 'load-json-file';
 
 let lintText;
 allowUnsafeNewFunction(() => {
@@ -22,16 +22,15 @@ function lint(textEditor) {
 		return [];
 	}
 
-	// check if package.json has 'xo'
-	const rgx = new RegExp('xo', 'g');
-	const pkg = fs.readFileSync(path.join(dir, 'package.json'), 'utf8');
-	if (!rgx.test(pkg)) {
-		return [];
-	}
-
 	// ugly hack to workaround ESLint's lack of a `cwd` option
 	const defaultCwd = process.cwd();
 	process.chdir(dir);
+
+	// check if package.json has dependency or devDependency
+	const pkg = loadJson('package.json');
+	if (!pkg.dependencies.xo && !pkg.devDependencies.xo) {
+		return [];
+	}
 
 	allowUnsafeNewFunction(() => {
 		report = lintText(textEditor.getText(), {cwd: dir});

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "atom-package-deps": "^3.0.0",
     "atom-set-text": "^1.0.1",
+    "load-json-file": "^1.1.0",
     "loophole": "^1.1.0",
     "pkg-dir": "^1.0.0",
     "xo": "^0.12.0"


### PR DESCRIPTION
Linter will only run if ~~any **one** of the following is true:~~

~~- an `.eslintrc` file exists~~
- a `package.json` exists & contains the word~~s~~ "xo"~~, "eslint", or "eslintConfig" (can be matched as config keys or dependency names)~~

If accepted, will resolve #5 

Also, this also fixes a fatal error I was experiencing when working on projects where no `package.json` exists.