### PR TITLE
Add links to rule documentation in linting reports (fixes #32)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import {allowUnsafeNewFunction} from 'loophole';
 import setText from 'atom-set-text';
 import pkgDir from 'pkg-dir';
 import {sync as loadJson} from 'load-json-file';
+import ruleURI from 'eslint-rule-documentation';
 
 let lintText;
 allowUnsafeNewFunction(() => {
@@ -62,7 +63,7 @@ function lint(textEditor) {
 			filePath,
 			fix,
 			type: x.severity === 2 ? 'Error' : 'Warning',
-			text: `${x.message} (${x.ruleId})`
+			html: `<span>${x.message} (<a href=${ruleURI(x.ruleId).url}>${x.ruleId}</a>)</span>`
 		};
 
 		// some messages don't have these

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function lint(textEditor) {
 			filePath,
 			fix,
 			type: x.severity === 2 ? 'Error' : 'Warning',
-			html: `<span>${x.message} (<a href=${ruleURI(x.ruleId).url}>${x.ruleId}</a>)</span>`
+			html: `<span>${x.message} (<a href=${ruleURI(x.ruleId || '').url}>${x.ruleId}</a>)</span>`
 		};
 
 		// some messages don't have these

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "atom-package-deps": "^4.0.1",
     "atom-set-text": "^1.0.1",
+    "eslint-rule-documentation": "^1.0.0",
     "load-json-file": "^1.1.0",
     "loophole": "^1.1.0",
     "pkg-dir": "^1.0.0",


### PR DESCRIPTION
Add links to rule documentation in linting reports (fixes #32)

Looks similar to what was around before, but now it simply has that nice link to the rule's documentation :)