### PR TITLE
Temporary fix: add support for two `package.json` structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ allowUnsafeNewFunction(() => {
 
 function lint(textEditor) {
 	const filePath = textEditor.getPath();
-	const dir = pkgDir.sync(path.dirname(filePath));
+	let dir = pkgDir.sync(path.dirname(filePath));
 
 	// no package.json
 	if (!dir) {
@@ -26,7 +26,13 @@ function lint(textEditor) {
 	const defaultCwd = process.cwd();
 	process.chdir(dir);
 
-	const pkg = loadJson(path.join(dir, 'package.json'));
+	let pkg = loadJson(path.join(dir, 'package.json'));
+
+	// get the parent `package.json` if there's a `"xo": false` in the current one
+	if (pkg.xo !== undefined && pkg.xo === false) {
+		dir = path.join(dir, '..');
+		pkg = loadJson(path.join(dir, 'package.json'));
+	}
 
 	// only lint when `xo` is a dependency
 	if (!(pkg.dependencies && pkg.dependencies.xo) &&

--- a/index.js
+++ b/index.js
@@ -29,11 +29,14 @@ function lint(textEditor) {
 	let pkg = loadJson(path.join(dir, 'package.json'));
 
 	// get the parent `package.json` if there's a `"xo": false` in the current one
-	if (pkg.xo !== undefined) {
-		while (pkg.xo === false && dir !== null) {
-			dir = pkgDir.sync(path.join(dir, '..'));
-			pkg = dir === null ? pkg : loadJson(path.join(dir, 'package.json'));
-		}
+	while (pkg.xo === false && dir !== null) {
+		dir = pkgDir.sync(path.join(dir, '..'));
+		pkg = dir === null ? pkg : loadJson(path.join(dir, 'package.json'));
+	}
+
+	// `pkg.xo === false` && xo is a dependency && there's no parent `package.json`
+	if (dir === null) {
+		return [];
 	}
 
 	// only lint when `xo` is a dependency

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function lint(textEditor) {
 
 	// get the parent `package.json` if there's a `"xo": false` in the current one
 	if (pkg.xo !== undefined && pkg.xo === false) {
-		dir = path.join(dir, '..');
+		dir = pkgDir.sync(path.join(dir, '..'));
 		pkg = loadJson(path.join(dir, 'package.json'));
 	}
 

--- a/index.js
+++ b/index.js
@@ -29,9 +29,11 @@ function lint(textEditor) {
 	let pkg = loadJson(path.join(dir, 'package.json'));
 
 	// get the parent `package.json` if there's a `"xo": false` in the current one
-	if (pkg.xo !== undefined && pkg.xo === false) {
-		dir = pkgDir.sync(path.join(dir, '..'));
-		pkg = loadJson(path.join(dir, 'package.json'));
+	if (pkg.xo !== undefined) {
+		while (pkg.xo === false && dir !== null) {
+			dir = pkgDir.sync(path.join(dir, '..'));
+			pkg = dir === null ? pkg : loadJson(path.join(dir, 'package.json'));
+		}
 	}
 
 	// only lint when `xo` is a dependency


### PR DESCRIPTION
See #37 for the discussion.

~~This is just a temporary fix since it only looks up in the immediate parent directory (`dir = path.join(dir, '..');`.~~ Also, @sindresorhus would like to move the entire logic to XO.

It works for me at [wulkano/kap](https://github.com/wulkano/kap) and should also work for us at [zeit/hyper](https://github.com/zeit/hyper) 😄 ✨ 

_Closes #37_