### PR TITLE
Smarter ranges

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,14 +74,18 @@ function lint(textEditor) {
 		// taken from linter-eslint
 		let range;
 		const msgLine = x.line - 1;
-		if (typeof x.endColumn === 'number' && typeof x.endLine === 'number') {
-			const msgCol = Math.max(0, x.column - 1);
-			range = [[msgLine, msgCol], [x.endLine - 1, x.endColumn - 1]];
-		} else if (typeof x.line === 'number' && typeof x.column === 'number') {
-			// We want msgCol to remain undefined if it was initially so
-			// `rangeFromLineNumber` will give us a range over the entire line
-			const msgCol = typeof x.column === 'undefined' ? x.column : x.column - 1;
-			range = rangeFromLineNumber(textEditor, msgLine, msgCol);
+		try {
+			if (typeof x.endColumn === 'number' && typeof x.endLine === 'number') {
+				const msgCol = Math.max(0, x.column - 1);
+				range = [[msgLine, msgCol], [x.endLine - 1, x.endColumn - 1]];
+			} else if (typeof x.line === 'number' && typeof x.column === 'number') {
+				// We want msgCol to remain undefined if it was initially so
+				// `rangeFromLineNumber` will give us a range over the entire line
+				const msgCol = typeof x.column === 'undefined' ? x.column : x.column - 1;
+				range = rangeFromLineNumber(textEditor, msgLine, msgCol);
+			}
+		} catch (err) {
+			throw new Error(`Cannot mark location in editor for (${x.ruleId}) - (${x.message}) at line (${x.line}) column (${x.column})`);
 		}
 
 		const ret = {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function lint(textEditor) {
 			try {
 				range = rangeFromLineNumber(textEditor, msgLine, msgCol);
 			} catch (err) {
-				throw new Error(`Cannot mark location in editor for (${x.ruleId}) - (${x.message}) at line (${x.line}) column (${x.column})`);
+				throw new Error(`Error getting range, this is most likely an issue with ESLint. (${x.ruleId} - ${x.message} at ${x.line}:${x.column})`);
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -74,18 +74,18 @@ function lint(textEditor) {
 		// taken from linter-eslint
 		let range;
 		const msgLine = x.line - 1;
-		try {
-			if (typeof x.endColumn === 'number' && typeof x.endLine === 'number') {
-				const msgCol = Math.max(0, x.column - 1);
-				range = [[msgLine, msgCol], [x.endLine - 1, x.endColumn - 1]];
-			} else if (typeof x.line === 'number' && typeof x.column === 'number') {
-				// We want msgCol to remain undefined if it was initially so
-				// `rangeFromLineNumber` will give us a range over the entire line
-				const msgCol = typeof x.column === 'undefined' ? x.column : x.column - 1;
+		if (typeof x.endColumn === 'number' && typeof x.endLine === 'number') {
+			const msgCol = Math.max(0, x.column - 1);
+			range = [[msgLine, msgCol], [x.endLine - 1, x.endColumn - 1]];
+		} else if (typeof x.line === 'number' && typeof x.column === 'number') {
+			// We want msgCol to remain undefined if it was initially so
+			// `rangeFromLineNumber` will give us a range over the entire line
+			const msgCol = typeof x.column === 'undefined' ? x.column : x.column - 1;
+			try {
 				range = rangeFromLineNumber(textEditor, msgLine, msgCol);
+			} catch (err) {
+				throw new Error(`Cannot mark location in editor for (${x.ruleId}) - (${x.message}) at line (${x.line}) column (${x.column})`);
 			}
-		} catch (err) {
-			throw new Error(`Cannot mark location in editor for (${x.ruleId}) - (${x.message}) at line (${x.line}) column (${x.column})`);
 		}
 
 		const ret = {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "xo"
   ],
   "dependencies": {
+    "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
     "atom-set-text": "^1.0.1",
     "eslint-rule-documentation": "^1.0.0",


### PR DESCRIPTION
Grabbed the following features from `linter-eslint`, [here](https://github.com/AtomLinter/linter-eslint/blob/master/src/main.js#L201). Prior to this PR, this plugin did not have linter underline support; adding the ability to assume ranges when eslint doesn't provide a range fixes that. Additionally, if there is an `endColumn` and `endLine` present, it will use that instead of assuming.
- Add support for `endColumn` and `endLine`
- Add a smart fallback to assume a range
- Add a dependency to `atom-linter` for range assumption

Resolves #28
