### PR TITLE
fix: resolve xo, eslint and parser from cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,93 +1,12 @@
 /** @babel */
 import path from 'path';
 import {CompositeDisposable, Range} from 'atom';
-import {allowUnsafeNewFunction} from 'loophole';
+import {install} from 'atom-package-deps';
 import setText from 'atom-set-text';
 import pkgDir from 'pkg-dir';
 import {sync as loadJson} from 'load-json-file';
 import ruleURI from 'eslint-rule-documentation';
-
-let lintText;
-allowUnsafeNewFunction(() => {
-	lintText = require('xo').lintText;
-});
-
-function lint(textEditor) {
-	const filePath = textEditor.getPath();
-	let dir = pkgDir.sync(path.dirname(filePath));
-
-	// no package.json
-	if (!dir) {
-		return [];
-	}
-
-	let pkg = loadJson(path.join(dir, 'package.json'));
-
-	// get the parent `package.json` if there's a `"xo": false` in the current one
-	while (pkg.xo === false && dir !== null) {
-		dir = pkgDir.sync(path.join(dir, '..'));
-		pkg = dir === null ? pkg : loadJson(path.join(dir, 'package.json'));
-	}
-
-	// `pkg.xo === false` && xo is a dependency && there's no parent `package.json`
-	if (dir === null) {
-		return [];
-	}
-
-	// only lint when `xo` is a dependency
-	if (!(pkg.dependencies && pkg.dependencies.xo) &&
-		!(pkg.devDependencies && pkg.devDependencies.xo)) {
-		return [];
-	}
-
-	// ugly hack to workaround ESLint's lack of a `cwd` option
-	// TODO: remove this when https://github.com/sindresorhus/atom-linter-xo/issues/19 is resolved
-	const defaultCwd = process.cwd();
-	process.chdir(dir);
-
-	let report;
-	allowUnsafeNewFunction(() => {
-		report = lintText(textEditor.getText(), {
-			cwd: dir,
-			filename: filePath
-		});
-	});
-
-	process.chdir(defaultCwd);
-
-	const textBuffer = textEditor.getBuffer();
-
-	return report.results[0].messages.map(x => {
-		let fix;
-
-		if (x.fix) {
-			fix = {
-				range: new Range(
-					textBuffer.positionForCharacterIndex(x.fix.range[0]),
-					textBuffer.positionForCharacterIndex(x.fix.range[1])
-				),
-				newText: x.fix.text
-			};
-		}
-
-		const ret = {
-			filePath,
-			fix,
-			type: x.severity === 2 ? 'Error' : 'Warning',
-			html: `<span>${x.message} (<a href=${ruleURI(x.ruleId || '').url}>${x.ruleId}</a>)</span>`
-		};
-
-		// some messages don't have these
-		if (typeof x.line === 'number' && typeof x.column === 'number') {
-			ret.range = [
-				[x.line - 1, x.column - 1],
-				[x.line - 1, x.column - 1]
-			];
-		}
-
-		return ret;
-	});
-}
+import lint from './lint';
 
 export function provideLinter() {
 	return {
@@ -99,15 +18,20 @@ export function provideLinter() {
 		],
 		scope: 'file',
 		lintOnFly: true,
-		lint
+		lint: editor => {
+			const lint = getEditorLint(editor);
+			const format = getEditorFormat(editor);
+			return lint().then(format);
+		}
 	};
 }
 
 export function activate() {
-	require('atom-package-deps').install('linter-xo');
+	install('linter-xo');
 
 	this.subscriptions = new CompositeDisposable();
-	this.subscriptions.add(atom.commands.add('atom-text-editor', {
+
+	const command = atom.commands.add('atom-text-editor', {
 		'XO:Fix': () => {
 			const editor = atom.workspace.getActiveTextEditor();
 
@@ -115,24 +39,122 @@ export function activate() {
 				return;
 			}
 
-			let report;
-
-			allowUnsafeNewFunction(() => {
-				report = lintText(editor.getText(), {
-					fix: true,
-					cwd: path.dirname(editor.getPath())
-				});
-			});
-
-			const output = report.results[0].output;
-
-			if (output) {
-				setText(output);
-			}
+			const lint = getEditorLint(editor);
+			const fix = getEditorFix();
+			return lint().then(fix);
 		}
-	}));
+	});
+
+	this.subscriptions.add(command);
 }
 
 export function deactivate() {
-	this.subscriptions.dispose();
+	if (this.subscriptions) {
+		this.subscriptions.dispose();
+	}
+}
+
+function getEditorFix() {
+	return report => {
+		const [result] = report.results;
+		if (result.output) {
+			setText(result.output);
+		}
+	};
+}
+
+function getEditorFormat(editor) {
+	const buffer = editor.getBuffer();
+	const filePath = editor.getPath();
+
+	return report => {
+		const [result] = report.results;
+		return result.messages.map(message => {
+			return {
+				filePath,
+				fix: selectMessageFix(message, buffer),
+				type: selectMessageType(message),
+				html: selecMessageHtml(message),
+				range: selectMessageRange(message)
+			};
+		});
+	};
+}
+
+function getEditorLint(editor) {
+	return () => {
+		const filePath = editor.getPath();
+		const packageDirectory = pkgDir.sync(path.dirname(filePath));
+
+		if (!packageDirectory) {
+			return [];
+		}
+
+		const pkg = getXOPackageJson(packageDirectory);
+
+		if (pkg.dir === null) {
+			return [];
+		}
+
+		const deps = pkg.data.dependencies || {};
+		const devDeps = pkg.data.devDependencies || {};
+
+		// only lint when `xo` is a dependency
+		if (!('xo' in deps) && !('xo' in devDeps)) {
+			return [];
+		}
+
+		const opts = {cwd: pkg.dir, config: pkg.data.xo, filename: editor.getPath()};
+		return performLint(editor.getText(), opts);
+	};
+}
+
+function selectMessageRange(message) {
+	if (typeof message.line !== 'number' || typeof message.column !== 'number') {
+		return null;
+	}
+	const y = message.line - 1;
+	const x = message.column - 1;
+	const cursor = [y, x];
+	return [cursor, cursor];
+}
+
+function selectMessageType(message) {
+	return message.severity === 2 ? 'Error' : 'Warning';
+}
+
+function selecMessageHtml(message) {
+	return `<span>${message.message} (<a href=${ruleURI(message.ruleId || '').url}>${message.ruleId}</a>)</span>`;
+}
+
+function selectMessageFix(message, buffer) {
+	if (!message.fix) {
+		return null;
+	}
+
+	const [fixStart, fixEnd] = message.fix.range || [null, null];
+	const startPos = buffer.positionForCharacterIndex(fixStart);
+	const endPos = buffer.positionForCharacterIndex(fixEnd);
+
+	return {
+		range: new Range(startPos, endPos),
+		newText: message.fix.text
+	};
+}
+
+function performLint(text, opts) {
+	const payload = {text, opts};
+	return lint(payload);
+}
+
+function getXOPackageJson(dir) {
+	let data = loadJson(path.join(dir, 'package.json'));
+
+	// get the parent `package.json` if there's a `"xo": false` in the current one
+	while (data.xo === false && dir !== null) {
+		dir = pkgDir.sync(path.join(dir, '..'));
+		data = dir === null ? data : loadJson(path.join(dir, 'package.json'));
+	}
+
+	return {dir, data};
 }

--- a/index.js
+++ b/index.js
@@ -68,6 +68,10 @@ function getEditorFormat(editor) {
 	const filePath = editor.getPath();
 
 	return report => {
+		if (!report) {
+			return [];
+		}
+
 		const [result] = report.results;
 		return result.messages.map(message => {
 			return {
@@ -87,13 +91,13 @@ function getEditorLint(editor) {
 		const packageDirectory = pkgDir.sync(path.dirname(filePath));
 
 		if (!packageDirectory) {
-			return [];
+			return Promise.resolve();
 		}
 
 		const pkg = getXOPackageJson(packageDirectory);
 
 		if (pkg.dir === null) {
-			return [];
+			return Promise.resolve();
 		}
 
 		const deps = pkg.data.dependencies || {};
@@ -101,7 +105,7 @@ function getEditorLint(editor) {
 
 		// only lint when `xo` is a dependency
 		if (!('xo' in deps) && !('xo' in devDeps)) {
-			return [];
+			return Promise.resolve();
 		}
 
 		const opts = {cwd: pkg.dir, config: pkg.data.xo, filename: editor.getPath()};

--- a/lint.js
+++ b/lint.js
@@ -1,0 +1,51 @@
+/** @babel */
+import path from 'path';
+import {fork} from 'child_process';
+import uuid from 'uuid';
+
+export default function lint(payload) {
+	return new Promise((resolve, reject) => {
+		const worker = getWorker();
+		const id = uuid.v4();
+
+		const onMessage = message => {
+			if (message.error) {
+				reject(Object.assign(new Error(), message.error));
+				worker.removeListener('message', onMessage);
+				return;
+			}
+
+			if (message.id !== id) {
+				return;
+			}
+
+			resolve(message.payload);
+			worker.removeListener('message', onMessage);
+		};
+
+		worker.on('message', onMessage);
+		worker.on('error', reject);
+		worker.send({id, payload});
+	});
+}
+
+// Start a worker eagerly
+let runningWorker = getWorker();
+
+function getWorker() {
+	if (runningWorker) {
+		return runningWorker;
+	}
+
+	const workerPath = path.resolve(__dirname, './worker.js');
+	const worker = fork(workerPath, [], {silent: true});
+
+	worker.stdout.on('data', data => console.log(data.toString()));
+	worker.stderr.on('data', data => console.error(data.toString()));
+
+	worker.on('close', () => {
+		runningWorker = null;
+	});
+
+	return worker;
+}

--- a/package.json
+++ b/package.json
@@ -24,12 +24,17 @@
     "xo"
   ],
   "dependencies": {
+    "arson": "^0.2.3",
     "atom-package-deps": "^4.0.1",
     "atom-set-text": "^1.0.1",
     "eslint-rule-documentation": "^1.0.0",
+    "is-builtin-module": "^1.0.0",
     "load-json-file": "^2.0.0",
-    "loophole": "^1.1.0",
     "pkg-dir": "^1.0.0",
+    "proxyquire": "^1.7.10",
+    "resolve": "^1.1.7",
+    "serialize-error": "^2.0.0",
+    "uuid": "^2.0.3",
     "xo": "^0.17.0"
   },
   "package-deps": [

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,40 @@
+const proxyquire = require('proxyquire');
+const resolve = require('resolve');
+const serializeError = require('serialize-error');
+
+process.on('message', message => {
+	const {payload: {text, opts}} = message;
+	const {cwd, filename, config} = opts;
+
+	const xo = requireXO(cwd, config);
+	const report = xo.lintText(text, Object.assign({}, config || {}, {cwd, filename}));
+
+	process.send({
+		id: message.id,
+		payload: report
+	});
+});
+
+process.on('uncaughtException', err => {
+	process.send({error: serializeError(err)});
+});
+
+function tryResolveLocal(id, basedir) {
+	try {
+		return resolve.sync(id, {basedir});
+	} catch (err) {
+		return require.resolve(id);
+	}
+}
+
+function requireXO(cwd, config) {
+	const cwdResolved = ['xo', 'eslint', config.parser];
+
+	const stubs = cwdResolved.reduce((reg, id) => {
+		const modulePath = tryResolveLocal(id, cwd);
+		reg[id] = require(modulePath); // eslint-disable-line import/no-dynamic-require
+		return reg;
+	}, {});
+
+	return proxyquire('xo', stubs);
+}


### PR DESCRIPTION
This PR turned out way bigger than planned.
Hope the noise/gain ratio is good enough.

- tries to load xo, eslint an parser from cwd
- introduces fallback to __dirname if resolving fails
- uses proxyquire to load shareable config, plugins from cwd, too
- moves linting call to forked process
- removes loophole due to forked process making it obsolete

- targets #19
- targets #42
- targets #41