### PR TITLE
fix: avoid depending on on text-buffer on production

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -1,6 +1,5 @@
 /** @babel */
-import {Range} from 'text-buffer';
-// atom-linter prevents unit testing by depending on 'atom' directly
+import {Range} from 'atom';
 import {rangeFromLineNumber} from 'atom-linter';
 import ruleURI from 'eslint-rule-documentation';
 

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import proxyquire from 'proxyquire';
+import {Range} from 'text-buffer';
+import MockEditor from '../fixtures/mock-editor';
+
+const stubs = {
+	atom: {
+		Range,
+		'@noCallThru': true,
+		'@global': true
+	}
+};
+
+const editor = new MockEditor({path: '__fake'});
+
+const format = proxyquire('./format', stubs).default;
+
+test('for an empty report', t => {
+	const actual = format(editor)();
+	const expected = [];
+	t.deepEqual(actual, expected, 'it should return an empty array');
+});
+
+test('for a report with an error message', t => {
+	const input = {
+		results: [{
+			messages: [
+				{
+					message: 'message',
+					severity: 2
+				}
+			]
+		}]
+	};
+
+	const [actual] = format(editor)(input);
+	t.is(actual.type, 'Error', 'it should return an Error');
+	t.is(actual.html, '<span>message</span>', 'it should return appropriate html');
+});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "p-props": "^1.0.0",
     "pkg-dir": "^1.0.0",
     "resolve-from": "^2.0.0",
-    "text-buffer": "^9.4.3",
     "xo": "^0.17.0"
   },
   "devDependencies": {
@@ -46,6 +45,8 @@
     "delay": "^1.3.1",
     "electron-rebuild": "^1.4.0",
     "p-timeout": "^1.0.0",
+    "proxyquire": "^1.7.10",
+    "text-buffer": "^9.4.3",
     "tmp": "0.0.31"
   },
   "package-deps": [


### PR DESCRIPTION
* removes dependency on (native) text-buffer module on production
* introduces proxyquire for testing
* adds stub test for format.js

fixes #58