### PR TITLE
Add embedded JS to list of supported scopes

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ import lint from './lib/lint';
 const SUPPORTED_SCOPES = [
 	'source.js',
 	'source.jsx',
-	'source.js.jsx'
+	'source.js.jsx',
+	'source.js.embedded.html'
 ];
 
 export function activate() {


### PR DESCRIPTION
Supporting the `source.js.embedded.html` scope will add support for linting [Vue.js Single File Components](https://vuejs.org/v2/guide/single-file-components.html).