### PR TITLE
fix: harden format against reports without results

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -8,9 +8,9 @@ export default function format(editor) {
 	const buffer = editor.getBuffer();
 	const filePath = editor.getPath();
 
-	// (report: Object) => Array<Object>
+	// (report?: Object) => Array<Object>
 	return report => {
-		if (!report) {
+		if (!report || !report.results) {
 			return [];
 		}
 

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -21,6 +21,12 @@ test('for an empty report', t => {
 	t.deepEqual(actual, expected, 'it should return an empty array');
 });
 
+test('for a report without results', t => {
+	const actual = format(editor)({});
+	const expected = [];
+	t.deepEqual(actual, expected, 'it should return an empty array');
+});
+
 test('for a report with an error message', t => {
 	const input = {
 		results: [{


### PR DESCRIPTION
*  Return empty array if `result` is object without `results` key
*  Introduce relevant test case

fixes #61