### PR TITLE
Harden `format.js` against type errors

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -10,11 +10,22 @@ export default function format(editor) {
 
 	// (report?: Object) => Array<Object>
 	return report => {
-		if (!report || !report.results) {
+		if (!report) {
 			return [];
 		}
 
-		const [{messages}] = report.results;
+		const {results = []} = report;
+		const [result] = results;
+
+		if (!result) {
+			return [];
+		}
+
+		const {messages} = result;
+
+		if (!messages) {
+			return [];
+		}
 
 		return messages.map(message => {
 			return {

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -27,6 +27,12 @@ test('for a report without results', t => {
 	t.deepEqual(actual, expected, 'it should return an empty array');
 });
 
+test('for a report with empty results', t => {
+	const actual = format(editor)({results: []});
+	const expected = [];
+	t.deepEqual(actual, expected, 'it should return an empty array');
+});
+
 test('for a report with an error message', t => {
 	const input = {
 		results: [{


### PR DESCRIPTION
*  add test passing empty results array
*  refactor gateing code to be less terse and bug-prone (see #68, #61)

closes #68