### PR TITLE
Fix outdated comment

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -87,7 +87,7 @@ function selectPosition(editor, x) {
 		return [[msgLine, msgCol], [x.endLine - 1, x.endColumn - 1]];
 	} else if (typeof x.line === 'number' && typeof x.column === 'number') {
 		// We want msgCol to remain undefined if it was intentional so
-		// `rangeFromLineNumber` will give us a range over the entire line
+		// `generateRange` will give us a range over the entire line
 		const msgCol = typeof x.column === 'undefined' ? x.column : x.column - 1;
 
 		try {


### PR DESCRIPTION
`rangeFromLineNumber()` was changed to `generateRange()` in https://github.com/sindresorhus/atom-linter-xo/commit/cf31686b2ed3b3bba0e1c16bd745faed3ce9d4fb but the comment still referenced the old function name.