### PR TITLE
Add worker tests

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -8,7 +8,7 @@ let worker;
 module.exports.startWorker = startWorker;
 module.exports.stopWorker = stopWorker;
 
-function startWorker() {
+function startWorker(createWorker) {
 	if (worker) {
 		if (worker.childProcess.connected) {
 			return;
@@ -17,7 +17,7 @@ function startWorker() {
 		stopWorker();
 	}
 
-	worker = new Task(require.resolve('./xo-helper.js'));
+	worker = createWorker ? createWorker() : new Task(require.resolve('./xo-helper.js'));
 
 	worker.start([]);
 }

--- a/lib/worker.test.js
+++ b/lib/worker.test.js
@@ -1,0 +1,91 @@
+const test = require('ava');
+const pMapSeries = require('p-map-series');
+const proxyquire = require('proxyquire');
+const {CompositeDisposable} = require('event-kit');
+const {processMessages, MockTask} = require('../mocks/mock-task.js');
+
+const stubs = {
+	atom: {
+		CompositeDisposable,
+		'@noCallThru': true,
+		'@global': true
+	}
+};
+
+const {startWorker, stopWorker, lint} = proxyquire('./worker.js', stubs);
+
+test.afterEach(() => {
+	stopWorker();
+});
+
+test.serial('starting the worker starts a child process', t => {
+	const task = new MockTask();
+	startWorker(() => task);
+
+	t.true(task.childProcess.connected);
+});
+
+test.serial('stopping the worker terminates the child process', t => {
+	const task = new MockTask();
+	startWorker(() => task);
+	stopWorker();
+
+	t.false(task.childProcess.connected);
+});
+
+test.serial('lint sends a job to the child process', async t => {
+	const task = new MockTask();
+	startWorker(() => task);
+	const lintJob = lint('foo.js')('// some editor text');
+
+	processMessages(task);
+
+	const result = await lintJob;
+
+	t.deepEqual(result, {
+		editorText: '// some editor text',
+		filename: 'foo.js',
+		options: undefined,
+		type: 'lint'
+	});
+});
+
+test.serial('lint can send multiple concurrent jobs to the child process', async t => {
+	console.log('concurrent test');
+	const task = new MockTask();
+	startWorker(() => task);
+
+	const lintJobs = pMapSeries([
+		lint('foo.js')('// some editor text'),
+		lint('bar.js')('// some more editor text'),
+		lint('baz.js')('// some other editor text')
+	], job => {
+		processMessages(task);
+		return job;
+	});
+
+	processMessages(task);
+
+	const [fooResult, barResult, bazResult] = await lintJobs;
+
+	t.deepEqual(fooResult, {
+		editorText: '// some editor text',
+		filename: 'foo.js',
+		options: undefined,
+		type: 'lint'
+	});
+
+	t.deepEqual(barResult, {
+		editorText: '// some more editor text',
+		filename: 'bar.js',
+		options: undefined,
+		type: 'lint'
+	});
+
+	t.deepEqual(bazResult, {
+		editorText: '// some other editor text',
+		filename: 'baz.js',
+		options: undefined,
+		type: 'lint'
+	});
+});

--- a/mocks/mock-task.js
+++ b/mocks/mock-task.js
@@ -2,7 +2,7 @@ const {Emitter} = require('event-kit');
 
 const privateSpace = new WeakMap();
 
-module.exports.processMessages = function (task) {
+module.exports.processMessages = task => {
 	const {emitter, messages} = privateSpace.get(task);
 
 	for (const {id, ...message} of messages) {

--- a/mocks/mock-task.js
+++ b/mocks/mock-task.js
@@ -1,0 +1,47 @@
+const {Emitter} = require('event-kit');
+
+const privateSpace = new WeakMap();
+
+module.exports.processMessages = function (task) {
+	const {emitter, messages} = privateSpace.get(task);
+
+	for (const {id, ...message} of messages) {
+		emitter.emit(id, message);
+	}
+};
+
+module.exports.MockTask = class MockTask {
+	constructor() {
+		const messages = [];
+		privateSpace.set(this, {
+			childProcess: {connected: false},
+			emitter: new Emitter(),
+			messages
+		});
+	}
+
+	get childProcess() {
+		const {childProcess} = privateSpace.get(this);
+		return {...childProcess};
+	}
+
+	on(event, callback) {
+		const {emitter} = privateSpace.get(this);
+		return emitter.on(event, callback);
+	}
+
+	send(message) {
+		const {messages} = privateSpace.get(this);
+		return messages.push(message);
+	}
+
+	start() {
+		const {childProcess} = privateSpace.get(this);
+		childProcess.connected = true;
+	}
+
+	terminate() {
+		const {childProcess} = privateSpace.get(this);
+		childProcess.connected = false;
+	}
+};

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
 	},
 	"devDependencies": {
 		"ava": "^3.13.0",
+		"event-kit": "^2.5.3",
+		"p-map-series": "^2.1.0",
 		"proxyquire": "^2.0.1",
 		"text-buffer": "^13.15.2",
 		"tmp": "0.0.33"


### PR DESCRIPTION
`lib/worker.js` keeps an instance of `Task` in module scope, so calling `startWorker()` and `stopWroker()` updates the same instance.

This was a problem when running tests concurrently, as tests would be interacting with the same `Task` instance from other tests.

I think there are a few ways around this, but I was just looking for some input first